### PR TITLE
Add missing dependency to fix building with Stack/cabal new-build

### DIFF
--- a/include-file.cabal
+++ b/include-file.cabal
@@ -21,6 +21,7 @@ custom-setup
   setup-depends: base == 4.*
                , bytestring
                , random
+               , Cabal
 
 library
   exposed-modules: Development.IncludeFile


### PR DESCRIPTION
It looks to be fixing #1 - without it package build was failing locally with Stack+LTS-13.0 and `cabal new-build` (with `cabal-install` version 2.2.0.0)